### PR TITLE
Add basic email login guard

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { AuthGuard } from './auth.guard';
 import { BlankComponent } from './layouts/blank/blank.component';
 import { FullComponent } from './layouts/full/full.component';
 import { PublicDetailsComponent } from './maquicontrol/machines/public-details/public-details.component';
@@ -8,6 +9,8 @@ const routes: Routes = [
   {
     path: '',
     component: FullComponent,
+    canActivate: [AuthGuard],
+    canActivateChild: [AuthGuard],
     children: [
       {
         path: '',

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, CanActivateChild, ActivatedRouteSnapshot, RouterStateSnapshot, Router } from '@angular/router';
+import { AuthService } from './services/auth.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthGuard implements CanActivate, CanActivateChild {
+  constructor(private auth: AuthService, private router: Router) {}
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+    if (this.auth.isLoggedIn()) {
+      return true;
+    }
+    this.router.navigate(['/authentication/side-login']);
+    return false;
+  }
+
+  canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+    return this.canActivate(childRoute, state);
+  }
+}

--- a/src/app/pages/authentication/side-login/side-login.component.html
+++ b/src/app/pages/authentication/side-login/side-login.component.html
@@ -42,56 +42,24 @@
               >Your Admin Dashboard</span
             >
 
-            <div class="row m-t-24">
-              <div class="col-12 col-sm-6">
-                <button mat-stroked-button class="w-100">
-                  <div class="d-flex align-items-center">
-                    <img
-                      src="/assets/images/svgs/google-icon.svg"
-                      alt="google"
-                      width="16"
-                      class="m-r-8"
-                    />
-                    Sign in with Google
-                  </div>
-                </button>
-              </div>
-              <div class="col-12 col-sm-6">
-                <button
-                  mat-stroked-button
-                  class="w-100 d-flex align-items-center"
-                >
-                  <div class="d-flex align-items-center">
-                    <img
-                      src="/assets/images/svgs/facebook-icon.svg"
-                      alt="facebook"
-                      width="40"
-                      class="m-r-4"
-                    />
-                    Sign in with FB
-                  </div>
-                </button>
-              </div>
-            </div>
 
-            <div class="or-border m-t-30">or sign in with</div>
 
             <form class="m-t-30" [formGroup]="form" (ngSubmit)="submit()">
               <mat-label class="mat-subtitle-2 f-s-14 f-w-600 m-b-12 d-block"
-                >Username</mat-label
+                >Email</mat-label
               >
               <mat-form-field
                 appearance="outline"
                 class="w-100"
                 color="primary"
               >
-                <input matInput formControlName="uname" />
-                @if(f['uname'].touched && f['uname'].invalid) {
+                <input matInput formControlName="email" />
+                @if(f['email'].touched && f['email'].invalid) {
                 <mat-hint class="m-b-16 error-msg">
-                  @if(f['uname'].errors && f['uname'].errors['required']) {
-                  <div class="text-error">Name is required.</div>
-                  } @if(f['uname'].errors && f['uname'].errors['minlength']) {
-                  <div class="text-error">Name should be 6 character.</div>
+                  @if(f['email'].errors && f['email'].errors['required']) {
+                  <div class="text-error">Email is required.</div>
+                  } @if(f['email'].errors && f['email'].errors['email']) {
+                  <div class="text-error">Email is invalid.</div>
                   }
                 </mat-hint>
                 }

--- a/src/app/pages/authentication/side-login/side-login.component.ts
+++ b/src/app/pages/authentication/side-login/side-login.component.ts
@@ -3,6 +3,7 @@ import { CoreService } from 'src/app/services/core.service';
 import { FormGroup, FormControl, Validators, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { MaterialModule } from '../../../material.module';
+import { AuthService } from 'src/app/services/auth.service';
 
 @Component({
   selector: 'app-side-login',
@@ -13,10 +14,14 @@ import { MaterialModule } from '../../../material.module';
 export class AppSideLoginComponent {
   options = this.settings.getOptions();
 
-  constructor(private settings: CoreService, private router: Router) { }
+  constructor(
+    private settings: CoreService,
+    private router: Router,
+    private auth: AuthService
+  ) {}
 
   form = new FormGroup({
-    uname: new FormControl('', [Validators.required, Validators.minLength(6)]),
+    email: new FormControl('', [Validators.required, Validators.email]),
     password: new FormControl('', [Validators.required]),
   });
 
@@ -25,7 +30,11 @@ export class AppSideLoginComponent {
   }
 
   submit() {
-    // console.log(this.form.value);
-    this.router.navigate(['/dashboards/dashboard1']);
+    const { email, password } = this.form.value;
+    if (email && password && this.auth.login(email, password)) {
+      this.router.navigate(['/dashboards/dashboard1']);
+    } else {
+      this.form.setErrors({ invalid: true });
+    }
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthService {
+  private loggedIn = false;
+
+  login(email: string, password: string): boolean {
+    if (email === 'oskr@gmail.com' && password === '1234') {
+      this.loggedIn = true;
+      return true;
+    }
+    this.loggedIn = false;
+    return false;
+  }
+
+  logout(): void {
+    this.loggedIn = false;
+  }
+
+  isLoggedIn(): boolean {
+    return this.loggedIn;
+  }
+}


### PR DESCRIPTION
## Summary
- implement a simple `AuthService` with mock email/password
- protect private routes with `AuthGuard`
- adapt login page to use email/password only

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68405daa97648328a0756b17b6c653a3