### PR TITLE
Fix sticky card styles for public details component

### DIFF
--- a/src/app/maquicontrol/machines/public-details/public-details.component.scss
+++ b/src/app/maquicontrol/machines/public-details/public-details.component.scss
@@ -1,13 +1,13 @@
 .public-header {
-  position: -webkit-sticky;
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-  background: white;
   margin: 0;
 }
 
 .public-header mat-card {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  width: 100%;
   background: white;
   padding: 16px;
   display: flex;

--- a/src/app/maquicontrol/machines/public-details/public-details.component.ts
+++ b/src/app/maquicontrol/machines/public-details/public-details.component.ts
@@ -3,7 +3,7 @@ import { Component, HostListener } from '@angular/core';
 @Component({
   selector: 'app-public-details',
   templateUrl: './public-details.component.html',
-  styleUrl: './public-details.component.scss'
+  styleUrls: ['./public-details.component.scss']
 })
 export class PublicDetailsComponent {
   // Datos principales (puedes reemplazarlos con datos reales o @Input())


### PR DESCRIPTION
## Summary
- correct component metadata to load SCSS styles

## Testing
- `npm test` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_68414d31106483288f6565d2a3d79a21