### PR TITLE
Add backend API integration scaffolding

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -49,7 +49,13 @@
                   "maximumError": "12mb"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "all",
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ]
             },
             "development": {
               "buildOptimizer": false,

--- a/src/app/maquicontrol/machines/machines.component.ts
+++ b/src/app/maquicontrol/machines/machines.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { MatTableDataSource, MatTable } from '@angular/material/table';
+import { ApiService } from '../../services/api.service';
 
 export interface MachineElement {
   id: number;
@@ -16,22 +17,7 @@ export interface MachineElement {
   nombre_empresa: string;
 }
 
-const machines: MachineElement[] = [
-  {
-    id: 14,
-    marca: "Jaguar",
-    modelo: "Fiesta",
-    matricula: "123QWEQ",
-    num_parque: "3425454",
-    tipo_motor: "electrico",
-    imagen: "https://storage.googleapis.com/maquicontrol-90a19.firebasestorage.app/imgActivos/Icon.png?GoogleAccessId=maquicontrol-90a19%40appspot.gserviceaccount.com&Expires=1748286730&Signature=...",
-    anio_fabricacion: null,
-    num_serie: "1433543",
-    referencia: "imgActivos/Icon.png",
-    id_empresa: 2,
-    nombre_empresa: "Empresa Prueba"
-  }
-];
+const machines: MachineElement[] = [];
 
 @Component({
   selector: 'app-machines',
@@ -53,10 +39,12 @@ export class MachinesComponent implements OnInit {
     'accion'
   ];
 
-  constructor() {}
+  constructor(private api: ApiService) {}
 
   ngOnInit(): void {
-    this.dataSource = new MatTableDataSource(machines);
+    this.api.getMachines().subscribe((data) => {
+      this.dataSource = new MatTableDataSource(data);
+    });
   }
 
   applyFilter(filterValue: string): void {

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ApiService {
+  private baseUrl = environment.apiBaseUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getMachines(): Observable<any> {
+    return this.http.get(`${this.baseUrl}/machines`);
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiBaseUrl: 'https://maquicontrol-90a19.ew.r.appspot.com/api'
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBaseUrl: 'https://maquicontrol-90a19.ew.r.appspot.com/api'
+};


### PR DESCRIPTION
## Summary
- add environment configs with backend base URL
- configure Angular build to replace environment file in production
- create generic API service for HTTP requests
- load machine list from backend in machines component

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68443a1c669c83288ecf725bfabd92e2