### PR TITLE
Implement session token interceptor

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { HttpClientModule, HttpClient } from '@angular/common/http';
+import { HttpClientModule, HttpClient, HTTP_INTERCEPTORS } from '@angular/common/http';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -26,6 +26,7 @@ import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { PublicDetailsComponent } from './maquicontrol/machines/public-details/public-details.component';
 import { AppAccountSettingComponent } from './maquicontrol/account-setting/account-setting.component';
+import { TokenInterceptor } from './interceptors/token.interceptor';
 
 export function HttpLoaderFactory(http: HttpClient): any {
   return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -53,6 +54,13 @@ export function HttpLoaderFactory(http: HttpClient): any {
     FullComponent,
   ],
   exports: [TablerIconsModule],
+  providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: TokenInterceptor,
+      multi: true,
+    },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/app/interceptors/token.interceptor.ts
+++ b/src/app/interceptors/token.interceptor.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class TokenInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    // Skip adding the token for requests to the public-details endpoint
+    if (req.url.includes('public-details')) {
+      return next.handle(req);
+    }
+
+    const userString = localStorage.getItem('user');
+    if (userString) {
+      try {
+        const user = JSON.parse(userString);
+        const token = user?.token || user?.accessToken || user?.access_token;
+        if (token) {
+          const authReq = req.clone({
+            setHeaders: {
+              Authorization: `Bearer ${token}`
+            }
+          });
+          return next.handle(authReq);
+        }
+      } catch (e) {
+        // Parsing failed, continue without token
+      }
+    }
+    return next.handle(req);
+  }
+}


### PR DESCRIPTION
## Summary
- add a TokenInterceptor that injects the `user` token from localStorage into requests
- register the interceptor in `AppModule`

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6847e084d63c8328acbf11050cb49f5a