### PR TITLE
Add icon for machines menu

### DIFF
--- a/src/app/layouts/full/horizontal/sidebar/sidebar-data.ts
+++ b/src/app/layouts/full/horizontal/sidebar/sidebar-data.ts
@@ -11,6 +11,7 @@ export const navItems: NavItem[] = [
   },
   {
     displayName: 'Maquinarias',
+    iconName: 'truck',
     route: 'machines',
     children: [
       {

--- a/src/app/layouts/full/vertical/sidebar/sidebar-data.ts
+++ b/src/app/layouts/full/vertical/sidebar/sidebar-data.ts
@@ -11,6 +11,7 @@ export const navItems: NavItem[] = [
   },
   {
     displayName: 'Maquinarias',
+    iconName: 'truck',
     route: 'machines',
     children: [
       {


### PR DESCRIPTION
## Summary
- show machinery icon in vertical sidebar
- show machinery icon in horizontal menu

## Testing
- `npm test --silent` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684fd5dc1e28832886a9466f0a35e888