### PR TITLE
Add header dropdown for navigation

### DIFF
--- a/src/app/layouts/full/vertical/header/header.component.html
+++ b/src/app/layouts/full/vertical/header/header.component.html
@@ -34,6 +34,22 @@
   <span class="flex-1-auto"></span>
 
   <!-- --------------------------------------------------------------- -->
+  <!-- main Dropdown -->
+  <!-- --------------------------------------------------------------- -->
+  <button mat-button [matMenuTriggerFor]="mainMenu">Menú</button>
+  <mat-menu #mainMenu="matMenu">
+    <button mat-menu-item [routerLink]="['/dashboards/dashboard2']">
+      Dashboard
+    </button>
+    <button mat-menu-item [routerLink]="['/machines']">
+      Listar maquinarias
+    </button>
+    <button mat-menu-item [routerLink]="['/machines/create']">
+      Crear maquinarias
+    </button>
+  </mat-menu>
+
+  <!-- --------------------------------------------------------------- -->
   <!-- profile Dropdown -->
   <!-- --------------------------------------------------------------- -->
   <button


### PR DESCRIPTION
## Summary
- add a new dropdown menu in the header
  - quick access to dashboard
  - links to list and create machines

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684fe87c37c08328b8caa2fd7caa12ca