### PR TITLE
Implement global loading overlay

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,2 @@
+<app-loading></app-loading>
 <router-outlet></router-outlet>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,6 +5,7 @@ import { HttpClientModule, HttpClient, HTTP_INTERCEPTORS } from '@angular/common
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { LoadingComponent } from './shared/loading/loading.component';
 
 // icons
 import { TablerIconsModule } from 'angular-tabler-icons';
@@ -52,6 +53,7 @@ export function HttpLoaderFactory(http: HttpClient): any {
     }),
     NgScrollbarModule,
     FullComponent,
+    LoadingComponent,
   ],
   exports: [TablerIconsModule],
   providers: [

--- a/src/app/interceptors/token.interceptor.ts
+++ b/src/app/interceptors/token.interceptor.ts
@@ -1,32 +1,35 @@
 import { Injectable } from '@angular/core';
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import { LoadingService } from '../services/loading.service';
 
 @Injectable()
 export class TokenInterceptor implements HttpInterceptor {
-  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    // Skip adding the token for requests to the public-details endpoint
-    if (req.url.includes('public-details')) {
-      return next.handle(req);
-    }
+  constructor(private loadingService: LoadingService) {}
 
-    const userString = localStorage.getItem('user');
-    if (userString) {
-      try {
-        const user = JSON.parse(userString);
-        const token = user?.token || user?.accessToken || user?.access_token;
-        if (token) {
-          const authReq = req.clone({
-            setHeaders: {
-              Authorization: `Bearer ${token}`
-            }
-          });
-          return next.handle(authReq);
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    let request = req;
+    if (!req.url.includes('public-details')) {
+      const userString = localStorage.getItem('user');
+      if (userString) {
+        try {
+          const user = JSON.parse(userString);
+          const token = user?.token || user?.accessToken || user?.access_token;
+          if (token) {
+            request = req.clone({
+              setHeaders: {
+                Authorization: `Bearer ${token}`
+              }
+            });
+          }
+        } catch (e) {
+          // Parsing failed, continue without token
         }
-      } catch (e) {
-        // Parsing failed, continue without token
       }
     }
-    return next.handle(req);
+
+    this.loadingService.show();
+    return next.handle(request).pipe(finalize(() => this.loadingService.hide()));
   }
 }

--- a/src/app/services/loading.service.ts
+++ b/src/app/services/loading.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LoadingService {
+  private _loading$ = new BehaviorSubject<boolean>(false);
+  readonly loading$ = this._loading$.asObservable();
+  private requests = 0;
+
+  show(): void {
+    this.requests++;
+    if (this.requests === 1) {
+      this._loading$.next(true);
+    }
+  }
+
+  hide(): void {
+    if (this.requests > 0) {
+      this.requests--;
+    }
+    if (this.requests === 0) {
+      this._loading$.next(false);
+    }
+  }
+}

--- a/src/app/shared/loading/loading.component.html
+++ b/src/app/shared/loading/loading.component.html
@@ -1,0 +1,3 @@
+<div *ngIf="loading.loading$ | async" class="loading-overlay">
+  <mat-progress-spinner mode="indeterminate" color="primary"></mat-progress-spinner>
+</div>

--- a/src/app/shared/loading/loading.component.scss
+++ b/src/app/shared/loading/loading.component.scss
@@ -1,0 +1,12 @@
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.6);
+  z-index: 10000;
+}

--- a/src/app/shared/loading/loading.component.ts
+++ b/src/app/shared/loading/loading.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { LoadingService } from '../../services/loading.service';
+
+@Component({
+  selector: 'app-loading',
+  standalone: true,
+  imports: [CommonModule, MatProgressSpinnerModule],
+  templateUrl: './loading.component.html',
+  styleUrls: ['./loading.component.scss']
+})
+export class LoadingComponent {
+  constructor(public loading: LoadingService) {}
+}


### PR DESCRIPTION
## Summary
- add LoadingService to share HTTP loading state
- create standalone LoadingComponent for overlay spinner
- show the component in AppComponent
- wire service into TokenInterceptor to display spinner for requests

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6856e0bfb76c8328a4cb7ecfbee4d614