### PR TITLE
Add eye icon to view machine details

### DIFF
--- a/src/app/maquicontrol/machines/machines.component.html
+++ b/src/app/maquicontrol/machines/machines.component.html
@@ -63,6 +63,7 @@
         <ng-container matColumnDef="accion">
           <th mat-header-cell *matHeaderCellDef class="f-s-16 f-w-600">Acción</th>
           <td mat-cell *matCellDef="let element" class="action-link">
+            <a class="m-r-10 cursor-pointer"><i-tabler name="eye" [routerLink]="['/machines/details', element.id]" class="icon-18"></i-tabler></a>
             <a class="m-r-10 cursor-pointer"><i-tabler name="edit" [routerLink]="['/machines/update', element.id]" class="icon-18"></i-tabler></a>
             <a class="m-r-10 cursor-pointer"><i-tabler name="trash" class="icon-18"></i-tabler></a>
           </td>


### PR DESCRIPTION
## Summary
- add an eye icon in the action column of the machines table

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6856e35503a483289208590b51699f73