### PR TITLE
Fix loader visibility in detail pages

### DIFF
--- a/src/app/maquicontrol/machines/details-machine/details-machine.component.ts
+++ b/src/app/maquicontrol/machines/details-machine/details-machine.component.ts
@@ -1,12 +1,14 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
+import { finalize } from 'rxjs/operators';
 import { ApiService } from 'src/app/services/api.service';
+import { LoadingService } from 'src/app/services/loading.service';
 
 @Component({
   selector: 'app-details-machine',
   templateUrl: './details-machine.component.html',
-  styleUrl: './details-machine.component.scss'
+  styleUrls: ['./details-machine.component.scss']
 })
 export class DetailsMachineComponent implements OnInit {
   machine: any;
@@ -18,18 +20,22 @@ export class DetailsMachineComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     private http: HttpClient,
-    private api: ApiService
+    private api: ApiService,
+    private loadingService: LoadingService
   ) {}
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
     if (id) {
+      this.loadingService.show();
       this.fetchMachine(+id);
     }
   }
 
   fetchMachine(id: number): void {
-    this.api.getMachine(id).subscribe({
+    this.api.getMachine(id)
+      .pipe(finalize(() => this.loadingService.hide()))
+      .subscribe({
       next: (data) => {
         this.machine = data;
         this.mapSections();

--- a/src/app/maquicontrol/machines/public-details/public-details.component.html
+++ b/src/app/maquicontrol/machines/public-details/public-details.component.html
@@ -92,17 +92,17 @@
     <section class="seccion-info">
       <h4><mat-icon>phone</mat-icon> Contactos</h4>
       <div class="fila fila-contactos-h">
-        <a [href]="'tel:' + telefonos.comercial" class="enlace-contacto-h">
+        <a [href]="'tel:' + (telefonos?.comercial || '')" class="enlace-contacto-h">
           <button mat-stroked-button class="contacto-btn contacto-horizontal">
             👔 Comercial
           </button>
         </a>
-        <a [href]="'tel:' + telefonos.taller" class="enlace-contacto-h">
+        <a [href]="'tel:' + (telefonos?.taller || '')" class="enlace-contacto-h">
           <button mat-stroked-button class="contacto-btn contacto-horizontal" [disabled]="!telefonos?.taller">
             🔧 Taller
           </button>
         </a>
-        <a [href]="'tel:' + telefonos.oficina" class="enlace-contacto-h">
+        <a [href]="'tel:' + (telefonos?.oficina || '')" class="enlace-contacto-h">
           <button mat-stroked-button class="contacto-btn contacto-horizontal" [disabled]="!telefonos?.oficina">
             🏢 Oficina
           </button>

--- a/src/app/maquicontrol/machines/public-details/public-details.component.ts
+++ b/src/app/maquicontrol/machines/public-details/public-details.component.ts
@@ -1,6 +1,8 @@
 import { Component, HostListener, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { finalize } from 'rxjs/operators';
 import { ApiService } from 'src/app/services/api.service';
+import { LoadingService } from 'src/app/services/loading.service';
 
 @Component({
   selector: 'app-public-details',
@@ -41,7 +43,7 @@ export class PublicDetailsComponent implements OnInit {
     comercial?: string;
     taller?: string;
     oficina?: string;
-  } = {};
+  } | null = null;
 
   motorDiesel: any;
 
@@ -51,13 +53,18 @@ export class PublicDetailsComponent implements OnInit {
     this.expandir = y > 50;
   }
 
-  constructor(private route: ActivatedRoute, private apiService: ApiService) {}
+  constructor(
+    private route: ActivatedRoute,
+    private apiService: ApiService,
+    private loadingService: LoadingService
+  ) {}
 
   ngOnInit(): void {
     this.route.paramMap.subscribe(params => {
       const id = params.get('id');
       if (id) {
         this.activoId = +id;
+        this.loadingService.show();
         this.cargarDatosActivo();
         this.cargarBotones();
       }
@@ -65,7 +72,10 @@ export class PublicDetailsComponent implements OnInit {
   }
 
   cargarDatosActivo(): void {
-    this.apiService.getActivoById(this.activoId).subscribe({
+    this.apiService
+      .getActivoById(this.activoId)
+      .pipe(finalize(() => this.loadingService.hide()))
+      .subscribe({
       next: (data: any) => {
         const activo = data.activo;
         this.nombre = activo.nombre;
@@ -100,7 +110,11 @@ export class PublicDetailsComponent implements OnInit {
   }
 
   cargarBotones(): void {
-    this.apiService.getBotonesByActivoId(this.activoId).subscribe({
+    this.loadingService.show();
+    this.apiService
+      .getBotonesByActivoId(this.activoId)
+      .pipe(finalize(() => this.loadingService.hide()))
+      .subscribe({
       next: (data: any) => {
         this.acciones = data.botones || [];
       },


### PR DESCRIPTION
## Summary
- show/hide the loader in machine details page
- display loader while public details services load
- avoid warnings by letting telefonos be nullable
- fix template phone links

## Testing
- `npm run build`
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6856e9bc355883289cc93238cb130b54